### PR TITLE
Avoid automatic review from the @sonarsource/sonarcloud team

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @sonarsource/sonarcloud
+.github/CODEOWNERS @sonarsource/sonarcloud


### PR DESCRIPTION
@ismailcherri In your latest PR  the whole SonarCloud team was added as a reviewer. This is because of the CODEOWNERS file that any change on a file automatically gets forwarded to the whole team.

This PR would fix that behaviour in the future.